### PR TITLE
Make unicorn and ssedap production dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'pg', :group => [:production]
 
 # Auth
 gem 'cancan'
-gem "ssedap-client"
 gem "bartt-ssl_requirement", :require => "ssl_requirement"
 
 # Helper for nested pages
@@ -27,9 +26,12 @@ group :assets do
   gem 'uglifier', ">= 1.0.3"
   gem 'bootstrap-sass-rails'
 end
+
 group :production do
   gem 'libv8'
   gem 'therubyracer'
+  gem "ssedap-client"
+  gem 'unicorn'
 end
 
 # More asset stuff
@@ -38,9 +40,6 @@ gem 'ace-rails-ap'
 
 # Presentation
 gem 'redcarpet'
-
-# Use unicorn as the web server
-gem 'unicorn'
 
 # Testing
 gem 'cucumber-rails', :group => [:test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       factory_girl (~> 4.1.0)
       railties (>= 3.0.0)
     ffi (1.2.0)
+    ffi (1.2.0-x86-mingw32)
     fog (1.8.0)
       builder
       excon (~> 0.14)
@@ -95,6 +96,8 @@ GEM
       ruby-hmac
     formatador (0.2.4)
     gherkin (2.11.5)
+      json (>= 1.4.6)
+    gherkin (2.11.5-x86-mingw32)
       json (>= 1.4.6)
     hike (1.2.1)
     i18n (0.6.1)
@@ -118,8 +121,10 @@ GEM
       net-ssh (>= 1.99.1)
     net-ssh (2.6.2)
     nokogiri (1.5.5)
+    nokogiri (1.5.5-x86-mingw32)
     patron (0.4.18)
     pg (0.14.1)
+    pg (0.14.1-x86-mingw32)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.2)
@@ -189,6 +194,7 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.6)
+    sqlite3 (1.3.6-x86-mingw32)
     ssedap-client (0.0.4)
       json
       patron
@@ -215,6 +221,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   ace-rails-ap

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ See also [Momentum](/dorreneb/momentum) for the event tracking fork of this proj
 - RSpec ([link](https://www.relishapp.com/rspec))
 - Cucumber ([link](http://cukes.info/))
 
+# Windows development
+
+For developing on Windows, exclude production dependencies when installing
+Gems. Run this command after cloning the repository:
+
+    bundle install --without=production


### PR DESCRIPTION
WTF should now be able to be developed in Windows by excluding the "production" group when installing Gems.
