### PR TITLE
Events weekly view

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -226,6 +226,7 @@ h1, h2, h3, h4, h5, h6 {
 
   .list-item {
     padding: 7px;
+    height: 26px;
 
     &:nth-child(odd) {
       background: #eee;
@@ -255,6 +256,18 @@ h1, h2, h3, h4, h5, h6 {
 
         &:first-child { margin-left: 0; }
       }
+    }
+  }
+
+  .list-label{
+    font-weight:bold;
+    font-size:22px;
+    color:black;
+    padding-top:20px;
+    padding-bottom:5px;
+
+    &:first-child{
+      padding-top:0px;
     }
   }
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,8 @@ class EventsController < AdminController
       @when = :future
     end
 
+    @events = @events.group_by(&:week)
+
     respond_to do |format|
       format.html
       format.json { render json: @events }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,30 @@ class Event < ActiveRecord::Base
 
   before_validation :generate_short_name
 
+  ##
+  # Returns the week of the event in a hash of the format:
+  # {:start_day => <Sunday, 0:00:00 of the week>, 
+  #  :end_day   => <Saturday, 12:59:59 of the week>}
+  #
+  # Weeks are currently defined to start on sundays
+  #
+  # Can be used like: @events.group_by(&:week)
+  # (See the index for events controler/view)
+  def week
+    start_date = self.start_date.change({:hour => 0, :min => 0, :sec => 0})
+    end_date = self.end_date.change({:hour => 23, :min => 59, :sec => 59})
+
+    while !start_date.sunday?
+      start_date -= 1.day
+    end
+
+    while !end_date.saturday?
+      end_date += 1.day
+    end
+
+    return {start_day: start_date, end_day: end_date}
+  end
+
   private
 
   def generate_short_name
@@ -53,4 +77,6 @@ class Event < ActiveRecord::Base
       end
     end
   end
+
+
 end

--- a/app/views/events/_list_item.html.erb
+++ b/app/views/events/_list_item.html.erb
@@ -11,9 +11,9 @@
     %>
     <%= link_to raw("<i class=\"icon-pencil icon-white\"></i> Edit"),
       "#{edit_event_path(event)}#{params[:when]?'?when='+params[:when]:''}",
-      class: "btn btn-info" %>
+      class: "btn btn-info btn-small" %>
     <%= link_to raw("<i class=\"icon-trash icon-white\"></i> Delete"),
-      event, class: "btn btn-danger", confirm: 'Are you sure?', method: :delete %>
+      event, class: "btn btn-danger btn-small", confirm: 'Are you sure?', method: :delete %>
   </div>
 
   <div class="clear"></div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,9 @@
 <% title "Events" %>
 <h1>Events</h1>
+<% if can? :create, Event %>
+  <%= link_to raw("<i class=\"icon-plus icon-white\"></i> New Event"),
+  new_event_path, class: "btn btn-primary btn-small pull-right" %>
+<% end %>
 
 <ul class="nav nav-tabs">
 	<li <%= "class=active" if @when == :future%>>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -15,14 +15,14 @@
 
 <div class="edit-list">
   <% @events.each do |week, events| %>
-  	<h4> 
+  	<div class="list-label"> 
   		<%= week[:start_day].strftime("%b %-d") %>
   		 to 
   		<%= week[:end_day].strftime("%b %-d") %>
-  	</h4>
+  	</div>
   	<% events.each do |event| %>
     	<%= render partial: "list_item", locals: { event: event } %>
-	<% end %>
+	  <% end %>
   <% end %>
 </div>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,8 +14,15 @@
 </ul>
 
 <div class="edit-list">
-  <% @events.each do |event| %>
-    <%= render partial: "list_item", locals: { event: event } %>
+  <% @events.each do |week, events| %>
+  	<h4> 
+  		<%= week[:start_day].strftime("%b %-d") %>
+  		 to 
+  		<%= week[:end_day].strftime("%b %-d") %>
+  	</h4>
+  	<% events.each do |event| %>
+    	<%= render partial: "list_item", locals: { event: event } %>
+	<% end %>
   <% end %>
 </div>
 


### PR DESCRIPTION
Cleans up the admin events view. Fixes the "hover changes size" issue, groups events into weeks and adds a create event button at the top.

![Image of changes](https://f.cloud.github.com/assets/632557/246116/6121e412-8a95-11e2-9767-76928b694b9b.png)
