### PR TITLE
Gtv image fix

### DIFF
--- a/app/assets/javascripts/gtv_runner.coffee
+++ b/app/assets/javascripts/gtv_runner.coffee
@@ -81,7 +81,7 @@ class SSEEventPanelsView extends Backbone.View
     
 class SSEEventHighlightView extends Backbone.View
   initialize: ->
-    $("body").html(JST["templates/event_highlight"]( event: @options.event ))
+    $("body").html(JST["templates/event_highlight"]( event: @options.event, onload: @options.onload ))
 
 class SSEColorView extends Backbone.View
   initialize: ->
@@ -112,9 +112,9 @@ class SSEController extends Backbone.Router
     #this.three_week()
     #@countdown = pageSettings.three_week.timeAlive
     #@page = "three_week"
-    this.event_panels()
-    @countdown = pageSettings.event_panels.timeAlive
-    @page = "event_panels"
+    this.event_highlight()
+    @countdown = pageSettings.event_highlight.timeAlive
+    @page = "event_highlight"
     @timerId = setInterval(this.flipPage, 1000)
 
   flipPage: =>
@@ -183,6 +183,17 @@ class SSEController extends Backbone.Router
         if allEvents.length>0
           new SSEEventHighlightView
             event: allEvents[Math.floor(Math.random() * allEvents.length)]
+            onload: """
+              (function onload() {
+                  img = $('#main_image')
+                  var theImage = new Image();
+                  theImage.src = img.attr("src");
+                  if (Math.abs((theImage.height/theImage.width)-(img.height()/img.width()))>=0.001) {
+                    img.css('width','auto');
+                    img.css('height','100%');
+                  }
+              }).call()
+            """
         else
           that_scope.gotoPage(pageSettings["event_highlight"].nextPage)
       else

--- a/app/assets/javascripts/gtv_runner.coffee
+++ b/app/assets/javascripts/gtv_runner.coffee
@@ -112,9 +112,9 @@ class SSEController extends Backbone.Router
     #this.three_week()
     #@countdown = pageSettings.three_week.timeAlive
     #@page = "three_week"
-    this.event_highlight()
-    @countdown = pageSettings.event_highlight.timeAlive
-    @page = "event_highlight"
+    this.event_panels()
+    @countdown = pageSettings.event_panels.timeAlive
+    @page = "event_panels"
     @timerId = setInterval(this.flipPage, 1000)
 
   flipPage: =>
@@ -170,6 +170,7 @@ class SSEController extends Backbone.Router
       limit: 12
       can_feature: true
     that_scope = @
+    that_scope.event_count = that_scope.event_count or 0
     $.getJSON '../events', req, (data) ->
       if data
         allEvents = _(data).map (event) ->
@@ -181,8 +182,11 @@ class SSEController extends Backbone.Router
             return(n)
         )
         if allEvents.length>0
+          if that_scope.event_count>=allEvents.length
+            that_scope.event_count=0
+            
           new SSEEventHighlightView
-            event: allEvents[Math.floor(Math.random() * allEvents.length)]
+            event: allEvents[that_scope.event_count]
             onload: """
               (function onload() {
                   img = $('#main_image')
@@ -194,6 +198,7 @@ class SSEController extends Backbone.Router
                   }
               }).call()
             """
+          that_scope.event_count = that_scope.event_count+1
         else
           that_scope.gotoPage(pageSettings["event_highlight"].nextPage)
       else

--- a/app/assets/javascripts/root.js.coffee
+++ b/app/assets/javascripts/root.js.coffee
@@ -10,4 +10,3 @@ $ ->
     captionAnimationSpeed: 150,
     bullets: true
   )
-

--- a/app/assets/javascripts/templates/event_highlight.jst.eco
+++ b/app/assets/javascripts/templates/event_highlight.jst.eco
@@ -1,12 +1,10 @@
 
 <section class="container" style="position: relative">
-  <div class="gtv-event-header">
-    <h3>Event Highlight: <%= @event.shortName() %></h3>
-  </div>
-  
   <!-- We should only go to this page if there's an image for the event in the first place! Be warned!-->
   
-  <img src="<%=@event.image()%>" alt="Event Image" class="gtv-event-highlight" id="main_image"/>
+  <div class="gtv_img_container">
+  <center><img src="<%=@event.image()%>" alt="Event Image" class="gtv-event-highlight" id="main_image" onload="<%= @onload %>"/></center>
+  </div>
   
   <div class="gtv-highlight-footer"><center><h3><%=@event.startDay()%>, <%=@event.startHour()%> @ <%=@event.location()%></h3></center></div>
 </section> 

--- a/app/assets/stylesheets/gtv/master.scss
+++ b/app/assets/stylesheets/gtv/master.scss
@@ -276,14 +276,20 @@ thead .gtv-calendar-weekcol h3
 
 .gtv-event-highlight {
     position: absolute;
+    max-width: 1920px;
+    max-height: 1080px-$header_height;
+    display: block;
+    width: 100%;
     margin: auto;
     top: 0;
+    bottom: $header_height;
     left: 0;
     right: 0;
-    bottom: 0;
-    width:100%;
-    height:auto;
-    max-width: 1920px;
+}
+
+.gtv_img_container {
+    width: 1920px;
+    height: 1080px-$header_height;
 }
 
 .gtv-highlight-footer {


### PR DESCRIPTION
This fixes the scaling of images in the GTV events highlighter with some javascript magic.

In addition, as per offhand request, the event to feature is no longer chosen at random as it cycles through them all.
