### PR TITLE
Adds in current event route

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,8 @@
 class EventsController < AdminController
-  skip_before_filter :authenticate!, :only => [:public_index, :public_show, :gtv, :ftv]
+  skip_before_filter :authenticate!, :only => [:public_index, :public_show, :gtv, :ftv, :current]
 
   load_and_authorize_resource
-  skip_authorize_resource only: [:public_index, :public_show, :gtv, :ftv]
+  skip_authorize_resource only: [:public_index, :public_show, :gtv, :ftv, :current]
 
   # GET /admin/events
   # GET /admin/events.json
@@ -177,6 +177,14 @@ class EventsController < AdminController
 
   def ftv
     render :layout => false
+  end
+
+  def current
+    @event = Event.where("start_date >= ?", DateTime.now.to_date).order("start_date ASC").limit(1).first
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @event }
+    end
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Wtf::Application.routes.draw do
   post '/auth(/:action)', controller: 'auth'
 
   match '/events' => 'events#public_index', as: "events_public_events"
+  match '/events/current', to: 'events#current'
   match '/events/gtv', to: 'events#gtv'
   match '/events/ftv', to: 'events#ftv'
   match '/events(/:id)' => 'events#public_show', as: "events_public_show"


### PR DESCRIPTION
This adds a route /events/current. This was requested by the [LED Marquee](https://github.com/rit-sse/led-marquee) team.

This will let them easily grab the current or next event for presentation on the marquee.
